### PR TITLE
UD-like feature sorting

### DIFF
--- a/src/conllup/conllup.py
+++ b/src/conllup/conllup.py
@@ -80,12 +80,10 @@ def _featuresConllToJson(featuresConll: str) -> featuresJson_T:
 
 
 def _featuresJsonToConll(featuresJson: featuresJson_T) -> str:
-    splittedFeatureConll: List[str] = []
-    for [featureKey, featureValue] in featuresJson.items():
-        splittedFeatureConll.append(f"{featureKey}={featureValue}")
-    splittedFeatureConll.sort()
+    featureItems = list(featuresJson.items())
+    featureItems.sort(key=lambda item: item[0].lower())
+    splittedFeatureConll=[f"{item[0]}={item[1]}" for item in featureItems]
     featuresConll = "|".join(splittedFeatureConll)
-    featuresConll = featuresConll
     if featuresConll == "":
         featuresConll = "_"
     return featuresConll


### PR DESCRIPTION
In https://universaldependencies.org/format.html, it is said that: 
> _In sorting, uppercase letters are considered identical to their lowercase counterparts._

For instance:
```conllu
2	deuxième	deuxième	ADJ	_	NumType=Ord|Number=Sing	3	mod	_	_
```
is invalid. It should be:
```conllu
2	deuxième	deuxième	ADJ	_	Number=Sing|NumType=Ord	3	mod	_	_
```
