### PR TITLE
Handle token indices with decimals

### DIFF
--- a/src/conllup/conllup.py
+++ b/src/conllup/conllup.py
@@ -244,9 +244,9 @@ def _tokenJsonToConll(tokenJson: tokenJson_T) -> str:
     return tokenConll
 
 
-def _compareTokenIndexes(a: str, b: str) -> int:
-    a1 = int(a.split('-')[0])
-    b1 = int(b.split('-')[0])
+def _compareTokenIndexes(a: str, b: str) -> float:
+    a1 = float(a.split('-')[0])
+    b1 = float(b.split('-')[0])
     if a1 - b1 != 0:
         return a1 - b1
     else:


### PR DESCRIPTION
Enhanced UD allows decimal token indices to indicate elided or moved words, e.g. "Mary talked to Bill and Jane to Donald", where the second "talked" is elided.

Fixes the following issue in BertForDepRel, which occurred when running prediction on the En-GUM test connlu distributed with the UD treebank data:

```
Traceback (most recent call last):
  File "BertForDeprel/BertForDeprel/run.py", line 71, in <module>
    cmd(args, model_params)e. 37.51 seconds in file (28 sents/sec).
  File "/Users/nathanglenn/dev/workspaces/nonsense_workspace/BertForDeprel/BertForDeprel/parser/cmds/predict.py", line 233, in __call__
    writeConlluFile(path_result_file, predicted_sentences_json, overwrite=args.overwrite)
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 336, in writeConlluFile
    concatSentencesConll = _getStringForManySentencesJson(sentencesJson)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 328, in _getStringForManySentencesJson
    sentencesConll = [sentenceJsonToConll(sentenceJson) for sentenceJson in sentencesJson]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 328, in <listcomp>
    sentencesConll = [sentenceJsonToConll(sentenceJson) for sentenceJson in sentencesJson]
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 310, in sentenceJsonToConll
    treeConll = _treeJsonToConll(sentenceJson["treeJson"])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 285, in _treeJsonToConll
    sortedTokenIndexes = _sortTokenIndexes(tokenIndexes)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 278, in _sortTokenIndexes
    return sorted(tokenIndexes, key=functools.cmp_to_key(_compareTokenIndexes))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File venv/lib/python3.11/site-packages/conllup/conllup.py", line 266, in _compareTokenIndexes
    a1 = int(a.split('-')[0])
         ^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '26.1'
```

I don't actually know whether there are other places that need to be fixed as well, but this at least allows BertForDepRel to complete without erroring out. I'm not really sure how the prediction is working in that case, given that the input has an extra token.